### PR TITLE
ElasticSearch didn't understand string keys, only symbols

### DIFF
--- a/lib/output/elasticsearch_writer.rb
+++ b/lib/output/elasticsearch_writer.rb
@@ -5,7 +5,7 @@ module Stats
 
       def initialize(es_config=nil)
         defaults = { log: true, index: 'zoo-events', type: 'event' }
-        @config = defaults.merge(es_config)
+        @config = defaults.merge(hosts: es_config["hosts"])
         @client = Elasticsearch::Client.new(config)
       end
 


### PR DESCRIPTION
This probably worked fine on your machine since you're running Docker on localhost, which is the default host.