### PR TITLE
use explicit create option on index

### DIFF
--- a/lib/output/elasticsearch_writer.rb
+++ b/lib/output/elasticsearch_writer.rb
@@ -34,7 +34,7 @@ module Stats
 
         operations = events.map do |event|
           id = event_id(event)
-          doc = doc_defaults.merge(data: event, _id: id)
+          doc = doc_defaults.merge(data: event, _id: id, op_type: "create")
           {index: doc}
         end
 


### PR DESCRIPTION
force create only op to fail on updates when the doc already exists.

https://www.elastic.co/guide/en/elasticsearch/guide/current/bulk.html - "Each subrequest is executed independently, so the failure of one subrequest won’t affect the success of the others. If any of the requests fail, the top-level error flag is set to true and the error details will be reported under the relevant request:"