### PR TITLE
Api project filtering

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,3 @@ DEPENDENCIES
   rerun
   sinatra
   sinatra-contrib
-
-BUNDLED WITH
-   1.10.6

--- a/bin/start_stream
+++ b/bin/start_stream
@@ -12,8 +12,7 @@ require_relative '../lib/processor'
 require_relative '../lib/output/elasticsearch_writer'
 require_relative '../lib/models/classification'
 
-
-puts "Starting"
+puts "Starting Stream Reader"
 
 es_config = Stats::Config.load_yaml('elasticsearch.yml', environment)
 output  = Stats::Output::ElasticsearchWriter.new(es_config)
@@ -26,7 +25,7 @@ kafka_reader = Stats::Input::KafkaReader.new(processor:  processor,
                                              brokers:    kafka_config.fetch('brokers'),
                                              topic:      kafka_config.fetch('topic'))
 
-puts "Started"
+puts "Started Stream Reader"
 
 loop do
   kafka_reader.run

--- a/bin/start_stream
+++ b/bin/start_stream
@@ -14,7 +14,7 @@ require_relative '../lib/models/classification'
 
 puts "Starting Stream Reader"
 
-es_config = Stats::Config.load_yaml('elasticsearch.yml', environment)
+es_config = Stats::Config.load_yaml('elasticsearch.yml', environment).merge(log: Stats::Config.stats_development?)
 output  = Stats::Output::ElasticsearchWriter.new(es_config)
 processor = Stats::Processor.new(output)
 

--- a/lib/api/api.rb
+++ b/lib/api/api.rb
@@ -34,8 +34,7 @@ module Stats
       # move this to matching on event_type when this is in
       # https://github.com/zooniverse/Panoptes/issues/1525
       def event_type_query(type)
-        # { query: { match: { event_type: type } } }
-        { query: { wildcard: { event_type: "*.#{type}" } } }
+        { query: { match: { event_type: type } } }
       end
 
       def datetime_histogram(interval)

--- a/lib/api/elasticsearch_client.rb
+++ b/lib/api/elasticsearch_client.rb
@@ -14,7 +14,7 @@ module Stats
       private
 
       def defaults
-        @defaults = { log: true, index: 'zoo-events' }
+        @defaults = { log: Stats::Config.rack_development?, index: 'zoo-events' }
       end
 
       def es_config

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -2,6 +2,9 @@ require 'yaml'
 
 module Stats
   class Config
+
+    DEV_ENV = "development"
+
     def self.load_yaml(filename, environment)
       path = File.expand_path(File.join('..', '..', 'config', filename), __FILE__)
       YAML.load_file(path).fetch(environment.to_s)
@@ -13,6 +16,14 @@ module Stats
 
     def self.stats_environment
       ENV["ZOO_STATS_ENV"] || :development
+    end
+
+    def self.rack_development?
+      rack_environment == DEV_ENV
+    end
+
+    def self.stats_development?
+      stats_environment == DEV_ENV
     end
   end
 end

--- a/lib/output/elasticsearch_writer.rb
+++ b/lib/output/elasticsearch_writer.rb
@@ -3,8 +3,8 @@ module Stats
     class ElasticsearchWriter
       attr_reader :config, :client
 
-      def initialize(es_config=nil)
-        defaults = { log: true, index: 'zoo-events', type: 'event' }
+      def initialize(es_config)
+        defaults = { index: 'zoo-events', type: 'event' }
         @config = defaults.merge(hosts: es_config["hosts"])
         @client = Elasticsearch::Client.new(config)
       end

--- a/lib/output/elasticsearch_writer.rb
+++ b/lib/output/elasticsearch_writer.rb
@@ -13,18 +13,6 @@ module Stats
         client.cluster.health
       end
 
-      # def index
-      #   client.index index: config[:index], type: 'my-document', id: 1, body: { title: 'Test' }
-      # end
-
-      # def refresh_index
-      #   client.indices.refresh index: config[:index]
-      # end
-
-      # def search
-      #   client.search index: config["index"], body: { query: { match: { title: 'test' } } }
-      # end
-
       def get(id)
         client.get doc_defaults.merge(id: id)
       end


### PR DESCRIPTION
closes #8 - allow query param project_id for filtering, e.g. `http://localhost:3000/counts/classification/day?project_id=1313`. when missing defaults to zoo wide.