### PR TITLE
Custom configs at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ ADD ./ /zoo_stats
 
 ADD supervisord.conf /etc/supervisor/conf.d/zoo_event_stats.conf
 
-ENTRYPOINT exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
+ENTRYPOINT /zoo_stats/bin/start.sh

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -11,4 +11,4 @@ RUN bundle install
 
 ADD ./ /zoo_stats
 
-CMD bundle exec foreman start
+ENTRYPOINT /zoo_stats/bin/start.sh

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -ex
+
+cd /zoo_stats
+
+if [ -d "/zoo_stats_config/" ]
+then
+    ln -sf /zoo_stats_config/* ./config/
+fi
+
+if [ "$RACK_ENV" == "development" ]; then
+  exec bundle exec foreman start
+else
+  exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,29 @@
 elasticsearch:
   image: elasticsearch:1.7.3
-  ports:
-    - "9200:9200"
-    - "9300:9300"
+  # ports:
+  #   - "9200:9200"
+  #   - "9300:9300"
+
+zookeeper:
+  image: zooniverse/zookeeper
+  command: /usr/share/zookeeper/bin/zkServer.sh start-foreground -c localhost:2888:3888 -i 1
+
+kafka:
+  image: zooniverse/kafka
+  hostname: kafka
+  command: -i 1 -H kafka -p 9092 -z zk:2181
+  links:
+    - zookeeper:zk
 
 zoostats:
   dockerfile: Dockerfile.dev
   build: .
   ports:
     - "3000:3000"
+  environment:
+    RACK_ENV: development
+    ZOO_STATS_ENV: development
   links:
+    - zookeeper:zk
+    - kafka
     - elasticsearch


### PR DESCRIPTION
allow runtime configs to make it to the app before boot by using a custom start script that copies them over and leaves repo configs in place.