### PR TITLE
Logging updates to stop using up all the disk space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,4 @@ ADD ./ /zoo_stats
 
 ADD supervisord.conf /etc/supervisor/conf.d/zoo_event_stats.conf
 
-VOLUME /var/log/zoo-event-stats
-
 ENTRYPOINT /zoo_stats/bin/start.sh

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -8,6 +8,7 @@ directory=/zoo_stats
 autorestart=true
 redirect_stderr=true
 stdout_logfile=/var/log/zoo-event-stats/streamer.log
+logfile_backups=3
 
 [program:api]
 user=root
@@ -16,3 +17,4 @@ directory=/zoo_stats
 autorestart=true
 redirect_stderr=true
 stdout_logfile=/var/log/zoo-event-stats/api.log
+logfile_backups=3


### PR DESCRIPTION
closes #35 

Don't mount the container logs to the host and only keep 3 rotated log files.