### PR TITLE
Add subject ids to pusher stream

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,6 @@ group :development do
   gem 'foreman'
 end
 
-group :development, :test do
-  gem 'rspec'
+group :test do
+  gem 'minitest'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,6 @@ GEM
     byebug (8.2.2)
     coderay (1.1.0)
     debug_inspector (0.0.2)
-    diff-lcs (1.2.5)
     elasticsearch (1.0.15)
       elasticsearch-api (= 1.0.15)
       elasticsearch-transport (= 1.0.15)
@@ -49,6 +48,7 @@ GEM
       rb-inotify (>= 0.9)
     maxminddb (0.1.8)
     method_source (0.8.2)
+    minitest (5.9.1)
     multi_json (1.11.2)
     multipart-post (2.0.0)
     pry (0.10.3)
@@ -83,19 +83,6 @@ GEM
       listen (~> 3.0)
     rollbar (2.8.3)
       multi_json
-    rspec (3.4.0)
-      rspec-core (~> 3.4.0)
-      rspec-expectations (~> 3.4.0)
-      rspec-mocks (~> 3.4.0)
-    rspec-core (3.4.2)
-      rspec-support (~> 3.4.0)
-    rspec-expectations (3.4.0)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-mocks (3.4.1)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-support (3.4.1)
     sinatra (1.4.7)
       rack (~> 1.5)
       rack-protection (~> 1.4)
@@ -122,6 +109,7 @@ DEPENDENCIES
   foreman
   geocoder
   maxminddb
+  minitest
   pry
   pry-byebug
   pry-rescue
@@ -131,7 +119,6 @@ DEPENDENCIES
   rake
   rerun
   rollbar (~> 2.8.3)
-  rspec
   sinatra
   sinatra-contrib
   sinatra-cross_origin!

--- a/Rakefile
+++ b/Rakefile
@@ -92,3 +92,8 @@ task :stream => [:download_jars, "streamer.properties"] do |t|
   )
   sh *commands
 end
+
+desc "Run test suite"
+task :test do
+  Dir.glob('./test/*/*_test.rb').each { |file| require file }
+end

--- a/lib/models/panoptes_classification.rb
+++ b/lib/models/panoptes_classification.rb
@@ -1,3 +1,5 @@
+require_relative '../../lib/geo'
+
 module Models
   class PanoptesClassification < Base
     def id
@@ -14,6 +16,7 @@ module Models
         project_id: links["project"],
         workflow_id: links["workflow"],
         user_id: links["user"],
+        subject_ids: links["subjects"],
         geo: Geo.locate(data["user_ip"])
       }
     end

--- a/test/models/ouroboros_classification_test.rb
+++ b/test/models/ouroboros_classification_test.rb
@@ -1,0 +1,76 @@
+require_relative "../test_helper"
+require_relative '../../lib/models'
+
+module Models
+  class TestOuroborosClassification < Minitest::Test
+
+    def classification
+      @classification ||= Models.for(event)
+    end
+
+    def event_data(attribute)
+      event.dig("data",attribute)
+    end
+
+    def timestamp
+      @timestamp ||= DateTime.parse(event_data("timestamp"))
+    end
+
+    def subject_data
+      event_data("subject").map {|subject| subject["zooniverse_id"] }.join(",")
+    end
+
+    def test_timestamp
+      assert_equal(timestamp, classification.timestamp)
+    end
+
+    def test_attributes
+      expected = {
+        user_id: event_data("user_id"),
+        user_ip: nil,
+        subjects: subject_data,
+        lang: "Unknown",
+        user_agent: nil,
+        user_name: "Zookeeper",
+        data: nil,
+        created_at: timestamp,
+        project: event_data("project"),
+        geo: {}
+      }
+      assert_equal(expected, classification.attributes)
+    end
+
+    def event
+      {
+        "source" => "ouroboros",
+        "type" => "classification",
+        "version" => "1.0.0",
+        "timestamp" => "2016-10-10T14:46:41Z",
+        "data" => {
+          "project" => "galaxy_zoo",
+          "subject" => [{
+            "id" => "56f3de0c5925d900420319a7",
+            "activated_at" => "2016-10-07T21:00:38Z",
+            "created_at" => "2016-03-30T12:58:29Z",
+            "metadata" => { "redshift" => 0.02837243862450123 },
+            "project_id" => "502a90cd516bcb060c000001",
+            "random" => 0.3,
+            "state" => "active",
+            "updated_at" => "2016-03-30T12:58:29Z",
+            "workflow_ids" => ["55db7cf01766276e7b000002"],
+            "zooniverse_id" => "AGZ000bqmz"
+          }],
+          "timestamp" => "2016-10-10T14:46:41Z",
+          "user_ip" => "127.0.0.1",
+          "annotations" => [
+            {"lang" => "en"},
+            {"decals-0" => "a-1"}
+          ],
+          "user" => "Zookeeper",
+          "user_id" => "1"
+        },
+        "linked" => {}
+      }
+    end
+  end
+end

--- a/test/models/panoptes_classification_test.rb
+++ b/test/models/panoptes_classification_test.rb
@@ -1,0 +1,143 @@
+require_relative "../test_helper"
+require_relative '../../lib/models'
+
+module Models
+  class TestPanoptesClassification < Minitest::Test
+
+    def panoptes_classification
+      @panoptes_classification ||= Models.for(event)
+    end
+
+    def event_data(attribute)
+      event.dig("data",attribute)
+    end
+
+    def link_data(link)
+      event_data("links").dig(link)
+    end
+
+    def test_id
+      assert_equal(event_data("id"), panoptes_classification.id)
+    end
+
+    def test_timestamp
+      expected = DateTime.parse(event_data("updated_at"))
+      assert_equal(expected, panoptes_classification.timestamp)
+    end
+
+    def test_attributes
+      expected = {
+        classification_id: event_data("id"),
+        project_id: link_data("project"),
+        workflow_id: link_data("workflow"),
+        user_id: link_data("user"),
+        subject_ids: link_data("subjects"),
+        geo: {}
+      }
+      assert_equal(expected, panoptes_classification.attributes)
+    end
+
+    def event
+      {
+        "source" => "panoptes",
+        "type" => "classification",
+        "version" => "1.0.0",
+        "timestamp" => "2016-10-10T12:59:48Z",
+        "data" => {
+           "id" => "18521902",
+           "created_at" => "2016-10-10T12:59:48.233Z",
+           "updated_at" => "2016-10-10T12:59:48.293Z",
+           "user_ip" => "127.0.0.1",
+           "workflow_version" => "2.5",
+           "gold_standard" =>  nil,
+           "expert_classifier" =>  nil,
+           "annotations" => [
+              {
+                 "task" => "init",
+                 "value" => 1
+              }
+           ],
+           "metadata" => {
+              "session" => "8c09ed53c6ee1b397d9ae6b6d1eef096a2c966debdc13678d2b151c8c82c3c8c",
+              "viewport" => {
+                 "width" => 1440,
+                 "height" => 661
+              },
+              "started_at" => "2016-10-10T12:59:44.812Z",
+              "user_agent" => "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:49.0) Gecko/20100101 Firefox/49.0",
+              "utc_offset" => "0",
+              "finished_at" => "2016-10-10T12:59:46.795Z",
+              "live_project" => true,
+              "user_language" => "en",
+              "user_group_ids" => [
+
+              ],
+              "subject_dimensions" => [
+                 {
+                    "clientWidth" => 480,
+                    "clientHeight" => 480,
+                    "naturalWidth" => 480,
+                    "naturalHeight" => 480
+                 }
+              ],
+              "workflow_version" => "2.5"
+           },
+           "href" => "/classifications/18521902",
+           "links" => {
+              "project" => "764",
+              "user" => "1",
+              "workflow" => "2303",
+              "workflow_content" => "2302",
+              "subjects" => ["3069945"]
+           }
+        },
+        "linked" => {
+           "projects" => [
+              {
+                 "id" => "764",
+                 "display_name" => "Pulsar Hunters",
+                 "created_at" => "2015-08-31T09:51:30.913Z",
+                 "href" => "/projects/764"
+              }
+           ],
+           "users" => [
+              {
+                 "id" => "1",
+                 "login" => "Zookeeper",
+                 "href" => "/users/1"
+              }
+           ],
+           "workflows" => [
+              {
+                 "id" => "2303",
+                 "display_name" => "Bluedot LOTAAS",
+                 "created_at" => "2016-07-22T16:47:46.489Z",
+                 "href" => "/workflows/2303"
+              }
+           ],
+           "workflow_contents" => [
+              {
+                 "id" => "2302",
+                 "created_at" => "2016-07-22T16:47:46.493Z",
+                 "updated_at" => "2016-07-22T18:03:04.964Z",
+                 "href" => "/workflow_contents/2302"
+              }
+           ],
+           "subjects" => [
+              {
+                 "id" => "3069945",
+                 "metadata" => {
+                    "DM" => "35.48",
+                    "S/N" => "4.4",
+                    "Period" => "15.98"
+                 },
+                 "created_at" => "2016-07-22T16:51:33.679Z",
+                 "updated_at" => "2016-07-22T16:51:33.679Z",
+                 "href" => "/subjects/3069945"
+              }
+           ]
+        }
+      }
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,2 @@
+require "minitest/autorun"
+require "pry"


### PR DESCRIPTION
closes #39 & https://github.com/zooniverse/Panoptes/issues/1958

this adds the subject ids into the panoptes stream and adds some tests around the formatting (better late than never).