### PR TITLE
gem updates and api error reporting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zooniverse/ruby:2.3.0
+FROM ruby:2.3
 
 MAINTAINER Campbell Allen
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM zooniverse/ruby:2.3.0
+FROM ruby:2.3
 
 MAINTAINER Campbell Allen
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,12 @@ source "https://rubygems.org"
 
 gem 'rake'
 gem 'aws-kclrb'
-gem 'elasticsearch'
+gem 'elasticsearch', '~> 1.1.2'
 gem 'faraday_middleware-aws-signers-v4'
 gem 'sinatra'
 gem 'sinatra-contrib'
 #CORS regex config
-gem "sinatra-cross_origin", github: 'britg/sinatra-cross_origin', branch: 'master'
+gem "sinatra-cross_origin"
 gem 'puma'
 gem 'pusher'
 gem 'geocoder'

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'puma'
 gem 'pusher'
 gem 'geocoder'
 gem 'maxminddb'
-gem 'rollbar', '~> 2.8.3'
+gem 'rollbar'
 
 group :development do
   gem 'rerun'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,102 +1,100 @@
-GIT
-  remote: git://github.com/britg/sinatra-cross_origin.git
-  revision: 2a66ffbc91a0e69d6c29d14dbaf92091542e3781
-  branch: master
-  specs:
-    sinatra-cross_origin (0.3.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
-    awesome_print (1.6.1)
-    aws-kclrb (1.0.0)
+    awesome_print (1.7.0)
+    aws-kclrb (1.0.1)
       multi_json (~> 1.0)
-    aws-sdk (2.2.3)
-      aws-sdk-resources (= 2.2.3)
-    aws-sdk-core (2.2.3)
+    aws-sdk (2.7.13)
+      aws-sdk-resources (= 2.7.13)
+    aws-sdk-core (2.7.13)
+      aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.2.3)
-      aws-sdk-core (= 2.2.3)
+    aws-sdk-resources (2.7.13)
+      aws-sdk-core (= 2.7.13)
+    aws-sigv4 (1.0.0)
     backports (3.6.8)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    byebug (8.2.2)
-    coderay (1.1.0)
+    byebug (9.0.6)
+    coderay (1.1.1)
     debug_inspector (0.0.2)
-    elasticsearch (1.0.15)
-      elasticsearch-api (= 1.0.15)
-      elasticsearch-transport (= 1.0.15)
-    elasticsearch-api (1.0.15)
+    elasticsearch (1.1.2)
+      elasticsearch-api (= 1.1.2)
+      elasticsearch-transport (= 1.1.2)
+    elasticsearch-api (1.1.2)
       multi_json
-    elasticsearch-transport (1.0.15)
+    elasticsearch-transport (1.1.2)
       faraday
       multi_json
-    faraday (0.9.2)
+    faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
     faraday_middleware-aws-signers-v4 (0.1.5)
       aws-sdk (~> 2.1)
       faraday (~> 0.9)
-    ffi (1.9.10)
-    foreman (0.78.0)
+    ffi (1.9.17)
+    foreman (0.83.0)
       thor (~> 0.19.1)
-    geocoder (1.2.14)
-    httpclient (2.7.0.1)
+    geocoder (1.4.3)
+    httpclient (2.8.3)
     interception (0.5)
-    jmespath (1.1.3)
-    listen (3.0.4)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
-    maxminddb (0.1.8)
+    jmespath (1.3.1)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
+    maxminddb (0.1.12)
     method_source (0.8.2)
-    minitest (5.9.1)
-    multi_json (1.11.2)
+    minitest (5.10.1)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
-    pry (0.10.3)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.3.0)
-      byebug (~> 8.0)
+    pry-byebug (3.4.2)
+      byebug (~> 9.0)
       pry (~> 0.10)
-    pry-rescue (1.4.2)
+    pry-rescue (1.4.5)
       interception (>= 0.5)
       pry
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
-    puma (2.15.3)
-    pusher (0.15.2)
-      httpclient (~> 2.5)
+    puma (3.7.1)
+    pusher (1.3.0)
+      httpclient (~> 2.7)
       multi_json (~> 1.0)
       pusher-signature (~> 0.1.8)
     pusher-signature (0.1.8)
-    rack (1.6.4)
+    rack (1.6.5)
     rack-protection (1.5.3)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
-    rake (11.1.2)
-    rb-fsevent (0.9.6)
-    rb-inotify (0.9.5)
+    rake (12.0.0)
+    rb-fsevent (0.9.8)
+    rb-inotify (0.9.8)
       ffi (>= 0.5.0)
     rerun (0.11.0)
       listen (~> 3.0)
     rollbar (2.8.3)
       multi_json
-    sinatra (1.4.7)
+    ruby_dep (1.5.0)
+    sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
-    sinatra-contrib (1.4.6)
+    sinatra-contrib (1.4.7)
       backports (>= 2.0)
       multi_json
       rack-protection
       rack-test
       sinatra (~> 1.4.0)
       tilt (>= 1.3, < 3)
+    sinatra-cross_origin (0.4.0)
     slop (3.6.0)
-    thor (0.19.1)
-    tilt (2.0.2)
+    thor (0.19.4)
+    tilt (2.0.6)
 
 PLATFORMS
   ruby
@@ -104,7 +102,7 @@ PLATFORMS
 DEPENDENCIES
   awesome_print
   aws-kclrb
-  elasticsearch
+  elasticsearch (~> 1.1.2)
   faraday_middleware-aws-signers-v4
   foreman
   geocoder
@@ -121,7 +119,7 @@ DEPENDENCIES
   rollbar (~> 2.8.3)
   sinatra
   sinatra-contrib
-  sinatra-cross_origin!
+  sinatra-cross_origin
 
 BUNDLED WITH
    1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       ffi (>= 0.5.0)
     rerun (0.11.0)
       listen (~> 3.0)
-    rollbar (2.8.3)
+    rollbar (2.14.0)
       multi_json
     ruby_dep (1.5.0)
     sinatra (1.4.8)
@@ -116,10 +116,10 @@ DEPENDENCIES
   pusher
   rake
   rerun
-  rollbar (~> 2.8.3)
+  rollbar
   sinatra
   sinatra-contrib
   sinatra-cross_origin
 
 BUNDLED WITH
-   1.11.2
+   1.14.5

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 
 require 'open-uri'
+require 'rollbar/rake_tasks'
 
 SAMPLES_DIR = File.dirname(__FILE__)
 JAR_DIR = File.join(SAMPLES_DIR, 'jars')
@@ -96,4 +97,11 @@ end
 desc "Run test suite"
 task :test do
   Dir.glob('./test/**/*_test.rb').each { |file| require file }
+end
+
+desc "Test rollbar integration"
+task :environment do
+  Rollbar.configure do |config |
+    config.access_token = ENV["ROLLBAR_ACCESS_TOKEN"]
+  end
 end

--- a/config.ru
+++ b/config.ru
@@ -3,4 +3,9 @@ require_relative 'lib/api/api'
 
 Bundler.require(:default, Stats::Config.rack_environment)
 
+Rollbar.configure do |config|
+  config.access_token = Stats::Config.rollbar_token
+  config.use_async = true
+end
+
 run Stats::Api::Api

--- a/config.ru
+++ b/config.ru
@@ -4,8 +4,11 @@ require_relative 'lib/api/api'
 Bundler.require(:default, Stats::Config.rack_environment)
 
 Rollbar.configure do |config|
+  enabled = use_async = !Stats::Config.stats_development?
   config.access_token = Stats::Config.rollbar_token
-  config.use_async = true
+  config.environment  = Stats::Config.stats_environment
+  config.enabled      = enabled
+  config.use_async    = use_async
 end
 
 run Stats::Api::Api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 elasticsearch:
-  image: elasticsearch:2.3.0
+  image: elasticsearch:1.5.2
   # ports:
   #   - "9200:9200"
   #   - "9300:9300"

--- a/lib/api/api.rb
+++ b/lib/api/api.rb
@@ -2,10 +2,14 @@ require 'sinatra'
 require "sinatra/json"
 require 'sinatra/cross_origin'
 require_relative '../es/client'
+require 'rollbar/middleware/sinatra'
 
 module Stats
   module Api
     class Api < Sinatra::Base
+
+      use Rollbar::Middleware::Sinatra
+
       register Sinatra::CrossOrigin
 
       get '/counts/?:type?/?:interval?\/?' do

--- a/test/models_test.rb
+++ b/test/models_test.rb
@@ -4,12 +4,12 @@ require_relative '../lib/models'
 class TestModels < Minitest::Test
   def test_unknown_source
     event = {"source" => "unknown", "type" => "classification"}
-    assert_equal(Models.for(event), nil)
+    assert_nil(Models.for(event))
   end
 
   def test_unknown_type
     event = {"source" => "panoptes", "type" => "unknown"}
-    assert_equal(Models.for(event), nil)
+    assert_nil(Models.for(event))
   end
 
   def test_known_type
@@ -17,4 +17,3 @@ class TestModels < Minitest::Test
     assert(Models.for(event).is_a?(Models::PanoptesClassification))
   end
 end
-


### PR DESCRIPTION
- update gems as there were deprecation errors in the logs
- add error reporting for the api via rollbar
- bump ruby mri versions
- test against AWS ES version

