### PR TITLE
use default debian jessie java version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ MAINTAINER Campbell Allen
 # Apt-get install dependencies
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get install --no-install-recommends -y git supervisor openjdk-7-jre-headless && \
+    apt-get install --no-install-recommends -y git supervisor default-jre-headless && \
     apt-get clean
 
-ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
+ENV JAVA_HOME /usr/bin/java
 
 WORKDIR /zoo_stats
 RUN mkdir log


### PR DESCRIPTION
openjdk-7-jre-headless won't build "Package 'openjdk-7-jre-headless' has no installation candidate" use this package which is openjdk-7 anyway. https://hub.docker.com/r/zooniverse/zoo-event-stats/builds/bpakycfyfhppya2gcxhew8m/