### PR TITLE
Edit cors_origins for NfN Field Book

### DIFF
--- a/lib/api/api.rb
+++ b/lib/api/api.rb
@@ -118,7 +118,7 @@ module Stats
       end
 
       def cors_origins
-        cors_origins = ENV["CORS_ORIGINS"] || '([a-z0-9-]+\.zooniverse\.org)'
+        cors_origins = ENV["CORS_ORIGINS"] || '([a-z0-9-]+\.zooniverse\.org|field-book(-preview)?\.notesfromnature\.org)'
         /^https?:\/\/#{cors_origins}(:\d+)?$/
       end
     end


### PR DESCRIPTION
Edits `cors_origins` regex to accept the following origins:
- https://field-book.notesfromnature.org
- https://field-book-preview.notesfromnature.org