### PR TITLE
Switch dockerfiles for independent services

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,24 @@
+FROM ruby:2.3
+
+MAINTAINER Campbell Allen
+
+# Apt-get install dependencies
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get install --no-install-recommends -y git supervisor && \
+    apt-get clean
+
+WORKDIR /zoo_stats
+
+ADD ./Gemfile /zoo_stats/
+ADD ./Gemfile.lock /zoo_stats/
+
+RUN bundle install --without development test
+
+EXPOSE 80
+
+ADD ./ /zoo_stats
+
+ADD supervisord.api.conf /etc/supervisor/conf.d/zoo_event_stats_api.conf
+
+ENTRYPOINT /zoo_stats/bin/start.sh

--- a/Dockerfile.stream
+++ b/Dockerfile.stream
@@ -24,6 +24,6 @@ EXPOSE 80
 
 ADD ./ /zoo_stats
 
-ADD supervisord.conf /etc/supervisor/conf.d/zoo_event_stats.conf
+ADD supervisord.stream.conf /etc/supervisor/conf.d/zoo_event_stats_stream.conf
 
 ENTRYPOINT /zoo_stats/bin/start.sh

--- a/supervisord.api.conf
+++ b/supervisord.api.conf
@@ -1,16 +1,6 @@
 [supervisord]
 nodaemon=true
 
-[program:event_stream]
-user=root
-command=bundle exec rake stream
-directory=/zoo_stats
-autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-
 [program:api]
 user=root
 command=bundle exec puma -C config/puma.rb

--- a/supervisord.stream.conf
+++ b/supervisord.stream.conf
@@ -1,0 +1,11 @@
+[supervisord]
+nodaemon=true
+
+[program:event_stream]
+user=root
+command=bundle exec rake stream
+directory=/zoo_stats
+autorestart=true
+redirect_stderr=true
+stdout_logfile=log/streamer.log
+logfile_backups=3


### PR DESCRIPTION
Linked to https://github.com/zooniverse/operations/pull/172

Allow the stream and api services to be be isolated from each other. Each service has it's own docker file that will be deployed as it's own stack.