### PR TITLE
create cache key from get request bodies

### DIFF
--- a/lib/es/client.rb
+++ b/lib/es/client.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 require_relative '../config'
+require_relative 'request_cache'
 require 'elasticsearch'
-require 'faraday_middleware'
 require 'faraday_middleware/aws_signers_v4'
 require 'typhoeus'
 require 'typhoeus/adapters/faraday'
@@ -28,7 +28,7 @@ module Stats
           expires_in: cache_expires_in.minutes
         )
         Elasticsearch::Client.new(config) do |f|
-          f.use FaradayMiddleware::Caching, cache
+          f.use Stats::Es::RequestCache, cache
 
           # use the middleware signers when talking to the elastic
           unless dev_env?

--- a/lib/es/request_cache.rb
+++ b/lib/es/request_cache.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+# Copied from https://github.com/lostisland/faraday_middleware/blob/af198df882c00b0c2e63a8f1cdae4b1db8cac194/lib/faraday_middleware/response/caching.rb
+# modified to include the request body of elastic search GET queries
+# Wat! - ES uses GET request bodies to specify the query!
+#      - I am not alone thinking that is bad practice:
+#      - https://stackoverflow.com/questions/36939748/elasticsearch-get-request-with-request-body
+#
+# Anyway, we live and learn, let's fix this :)
+
+require 'faraday'
+require 'forwardable'
+require 'digest/sha1'
+
+module Stats
+  module Es
+    # Public: Caches GET responses and pulls subsequent ones from the cache.
+    class RequestCache < Faraday::Middleware
+      attr_reader :cache
+      # Internal: List of status codes that can be cached:
+      # * 200 - 'OK'
+      # * 203 - 'Non-Authoritative Information'
+      # * 300 - 'Multiple Choices'
+      # * 301 - 'Moved Permanently'
+      # * 302 - 'Found'
+      # * 404 - 'Not Found'
+      # * 410 - 'Gone'
+      CACHEABLE_STATUS_CODES = [200, 203, 300, 301, 302, 404, 410].freeze
+
+      extend Forwardable
+      def_delegators :'Faraday::Utils', :parse_query, :build_query
+
+      # Public: initialize the middleware.
+      #
+      # cache   - An object that responds to read and write (default: nil).
+      # options - An options Hash (default: {}):
+      #           :ignore_params - String name or Array names of query
+      #                            params that should be ignored when forming
+      #                            the cache key (default: []).
+      #           :write_options - Hash of settings that should be passed as the
+      #                            third options parameter to the cache's #write
+      #                            method. If not specified, no options parameter
+      #                            will be passed.
+      #           :full_key      - Boolean - use full URL as cache key:
+      #                            (url.host + url.request_uri)
+      #
+      # Yields if no cache is given. The block should return a cache object.
+      def initialize(app, cache = nil, options = {})
+        super(app)
+        if cache.is_a?(Hash) && block_given?
+          options = cache
+          cache = nil
+        end
+        @cache = cache || yield
+        @options = options
+      end
+
+      def call(env)
+        if env[:method] == :get
+          if env[:parallel_manager]
+            # callback mode
+            cache_on_complete(env)
+          else
+            # synchronous mode
+            key = cache_key(env)
+            unless (response = cache.read(key)) && response
+              response = @app.call(env)
+              store_response_in_cache(key, response)
+            end
+            finalize_response(response, env)
+          end
+        else
+          @app.call(env)
+        end
+      end
+
+      def cache_key(env)
+        url = env[:url].dup
+        if url.query && params_to_ignore.any?
+          params = parse_query url.query
+          params.reject! { |k,| params_to_ignore.include? k }
+          url.query = params.any? ? build_query(params) : nil
+        end
+        url.normalize!
+        digest = if full_key?
+                   url.host + url.request_uri
+                 else
+                   url.request_uri
+                 end
+        digest_with_req_body = "#{digest}#{env.body}"
+        Digest::SHA1.hexdigest(digest_with_req_body)
+      end
+
+      def params_to_ignore
+        @params_to_ignore ||= Array(@options[:ignore_params]).map(&:to_s)
+      end
+
+      def full_key?
+        @full_key ||= @options[:full_key]
+      end
+
+      def cache_on_complete(env)
+        key = cache_key(env)
+        if (cached_response = cache.read(key))
+          finalize_response(cached_response, env)
+        else
+          # response.status is nil at this point
+          # any checks need to be done inside on_complete block
+          @app.call(env).on_complete do |response_env|
+            store_response_in_cache(key, response_env.response)
+            response_env
+          end
+        end
+      end
+
+      def store_response_in_cache(key, response)
+        return unless CACHEABLE_STATUS_CODES.include?(response.status)
+
+        if @options[:write_options]
+          cache.write(key, response, @options[:write_options])
+        else
+          cache.write(key, response)
+        end
+      end
+
+      def finalize_response(response, env)
+        response = response.dup if response.frozen?
+        env[:response] = response
+        unless env[:response_headers]
+          env.update response.env
+          # FIXME: omg hax
+          response.instance_variable_set('@env', env)
+        end
+        response
+      end
+    end
+  end
+end

--- a/lib/es/request_cache.rb
+++ b/lib/es/request_cache.rb
@@ -8,130 +8,15 @@
 #
 # Anyway, we live and learn, let's fix this :)
 
-require 'faraday'
-require 'forwardable'
-require 'digest/sha1'
+require 'faraday_middleware'
 
 module Stats
   module Es
-    # Public: Caches GET responses and pulls subsequent ones from the cache.
-    class RequestCache < Faraday::Middleware
-      attr_reader :cache
-      # Internal: List of status codes that can be cached:
-      # * 200 - 'OK'
-      # * 203 - 'Non-Authoritative Information'
-      # * 300 - 'Multiple Choices'
-      # * 301 - 'Moved Permanently'
-      # * 302 - 'Found'
-      # * 404 - 'Not Found'
-      # * 410 - 'Gone'
-      CACHEABLE_STATUS_CODES = [200, 203, 300, 301, 302, 404, 410].freeze
-
-      extend Forwardable
-      def_delegators :'Faraday::Utils', :parse_query, :build_query
-
-      # Public: initialize the middleware.
-      #
-      # cache   - An object that responds to read and write (default: nil).
-      # options - An options Hash (default: {}):
-      #           :ignore_params - String name or Array names of query
-      #                            params that should be ignored when forming
-      #                            the cache key (default: []).
-      #           :write_options - Hash of settings that should be passed as the
-      #                            third options parameter to the cache's #write
-      #                            method. If not specified, no options parameter
-      #                            will be passed.
-      #           :full_key      - Boolean - use full URL as cache key:
-      #                            (url.host + url.request_uri)
-      #
-      # Yields if no cache is given. The block should return a cache object.
-      def initialize(app, cache = nil, options = {})
-        super(app)
-        if cache.is_a?(Hash) && block_given?
-          options = cache
-          cache = nil
-        end
-        @cache = cache || yield
-        @options = options
-      end
-
-      def call(env)
-        if env[:method] == :get
-          if env[:parallel_manager]
-            # callback mode
-            cache_on_complete(env)
-          else
-            # synchronous mode
-            key = cache_key(env)
-            unless (response = cache.read(key)) && response
-              response = @app.call(env)
-              store_response_in_cache(key, response)
-            end
-            finalize_response(response, env)
-          end
-        else
-          @app.call(env)
-        end
-      end
-
+    class RequestCache < FaradayMiddleware::Caching
       def cache_key(env)
-        url = env[:url].dup
-        if url.query && params_to_ignore.any?
-          params = parse_query url.query
-          params.reject! { |k,| params_to_ignore.include? k }
-          url.query = params.any? ? build_query(params) : nil
-        end
-        url.normalize!
-        digest = if full_key?
-                   url.host + url.request_uri
-                 else
-                   url.request_uri
-                 end
+        digest = super(env)
         digest_with_req_body = "#{digest}#{env.body}"
         Digest::SHA1.hexdigest(digest_with_req_body)
-      end
-
-      def params_to_ignore
-        @params_to_ignore ||= Array(@options[:ignore_params]).map(&:to_s)
-      end
-
-      def full_key?
-        @full_key ||= @options[:full_key]
-      end
-
-      def cache_on_complete(env)
-        key = cache_key(env)
-        if (cached_response = cache.read(key))
-          finalize_response(cached_response, env)
-        else
-          # response.status is nil at this point
-          # any checks need to be done inside on_complete block
-          @app.call(env).on_complete do |response_env|
-            store_response_in_cache(key, response_env.response)
-            response_env
-          end
-        end
-      end
-
-      def store_response_in_cache(key, response)
-        return unless CACHEABLE_STATUS_CODES.include?(response.status)
-
-        if @options[:write_options]
-          cache.write(key, response, @options[:write_options])
-        else
-          cache.write(key, response)
-        end
-      end
-
-      def finalize_response(response, env)
-        response = response.dup if response.frozen?
-        env[:response] = response
-        unless env[:response_headers]
-          env.update response.env
-          # FIXME: omg hax
-          response.instance_variable_set('@env', env)
-        end
-        response
       end
     end
   end


### PR DESCRIPTION
I know what you are thinking, get request bodies wtf!?

Yep, elastic search uses this technique to communicate the json query object via the GET request search end point, so our caching needs to incorporate these get bodies into the cache key as the URL doesn't change (it's a static end point) https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html

I've overridden the faraday middleware cache class and modified it for our use case here, that should allow us to get code updates and get the modified behaviour we want.