### PR TITLE
remove production transport logging

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -81,8 +81,6 @@ spec:
                 memory: "600Mi"
                 cpu: "500m"
           env:
-            - name: ES_TRANSPORT_LOGGING
-              value: 'true'
             - name: RACK_ENV
               value: production
             - name: ZOO_STATS_ENV


### PR DESCRIPTION
the KCL subprocesses `KCLProcess` doesn't expose the transport logging via stderr (works in dev env). It appears that logging for this system is added in v2.0.0 https://github.com/awslabs/amazon-kinesis-client-ruby#release-200-february-26-2019, but we're on 1.0