### PR TITLE
use slim base images

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,7 +1,9 @@
-FROM ruby:2.6
+FROM ruby:2.6-slim
 
-RUN apt-get update && \
-    apt-get -y upgrade && \
+RUN apt-get update && apt-get -y upgrade && \
+    apt-get install --no-install-recommends -y \
+      build-essential \
+      libcurl4 && \
     apt-get clean
 
 WORKDIR /zoo_stats

--- a/Dockerfile.stream
+++ b/Dockerfile.stream
@@ -1,8 +1,10 @@
-FROM ruby:2.6
+FROM ruby:2.6-slim
 
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get install --no-install-recommends -y default-jre-headless && \
+    apt-get install --no-install-recommends -y \
+      build-essential \
+      default-jre-headless && \
     apt-get clean
 
 ARG RACK_ENV=production


### PR DESCRIPTION
decrease the number of installed packages which decreases the images size and also the number of possible security issues