### PR TITLE
increase ram limit

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -19,10 +19,10 @@ spec:
           image: zooniverse/zoo-event-stats:production-api-__IMAGE_TAG__
           resources:
               requests:
-                memory: "200Mi"
+                memory: "500Mi"
                 cpu: "30m"
               limits:
-                memory: "300Mi"
+                memory: "1000Mi"
                 cpu: "500m"
           env:
             - name: RACK_ENV


### PR DESCRIPTION
avoid OOM errors for this API bump to 1GB RAM limit
```
State:          Running
      Started:      Tue, 07 Jun 2022 19:37:07 +0100
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Sun, 05 Jun 2022 00:39:14 +0100
      Finished:     Tue, 07 Jun 2022 19:37:06 +0100
    Ready:          True
    Restart Count:  2
```