### PR TITLE
do not report 400 & 404 errors to rollbar

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -9,6 +9,12 @@ Rollbar.configure do |config|
   config.environment  = Stats::Config.stats_environment
   config.enabled      = enabled
   config.use_async    = use_async
+  # do not report these errors to rollbar
+  # https://docs.rollbar.com/docs/ruby#exception-level-filters
+  config.exception_level_filters.merge!({
+    'Sinatra::NotFound' => 'ignore',
+    'Sinatra::BadRequest' => 'ignore'
+  })
 end
 
 run Stats::Api::Api


### PR DESCRIPTION
these are noisy and impact on rollbar limits so we don't want to report them