### PR TITLE
add HPA to stats API service

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -130,3 +130,16 @@ spec:
       port: 80
       targetPort: 80
   type: NodePort
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: zoo-event-stats-production-api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: zoo-event-stats-production-api
+  minReplicas: 2
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 80


### PR DESCRIPTION
this PR adds a horizontal pod autoscaler to the stats API service, it'll run 2 API nodes by default to support https://stats.zooniverse.org and allow scaling up to 4 API pods while the CPU is above 80%