### PR TITLE
remove unneeded active_support require in api.rb and add active support notifications onto client

### DIFF
--- a/lib/api/api.rb
+++ b/lib/api/api.rb
@@ -5,7 +5,6 @@ require "sinatra/json"
 require 'sinatra/cross_origin'
 require_relative '../es/client'
 require 'rollbar/middleware/sinatra'
-require 'active_support'
 
 module Stats
   module Api

--- a/lib/es/client.rb
+++ b/lib/es/client.rb
@@ -7,6 +7,7 @@ require 'faraday_middleware/aws_signers_v4'
 require 'typhoeus'
 require 'typhoeus/adapters/faraday'
 require 'active_support/cache'
+require 'active_support/notifications'
 
 module Stats
   module Es


### PR DESCRIPTION
requiring active_support in api.rb is inefficient and overkill. instead requiring active_support/notifications onto client.rb where it is being used.

See: https://zooniverse.slack.com/archives/C0DTP3L2K/p1674525419985979