### PR TITLE
increase liveness probe timeout

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -50,7 +50,7 @@ spec:
               path: /
               port: 80
             # allow a longer response time than 1s
-            timeoutSeconds: 10
+            timeoutSeconds: 30
             periodSeconds: 30
           readinessProbe:
             httpGet:


### PR DESCRIPTION
allow long running queries to resolve within 30s before restarting the container