### PR TITLE
add circuit breaker system to faraday ES client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'rollbar'
 gem 'typhoeus'
 
 group :api do
+  gem 'circuitbox'
   gem 'puma'
   gem 'sinatra'
   gem 'sinatra-contrib'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,9 @@ GEM
     aws-sdk-resources (2.7.13)
       aws-sdk-core (= 2.7.13)
     aws-sigv4 (1.0.0)
+    circuitbox (1.1.1)
+      activesupport
+      moneta
     coderay (1.1.2)
     concurrent-ruby (1.1.10)
     elasticsearch (1.1.3)
@@ -45,6 +48,7 @@ GEM
     maxminddb (0.1.22)
     method_source (0.9.0)
     minitest (5.14.0)
+    moneta (1.5.2)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     mustermann (3.0.0)
@@ -91,6 +95,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   aws-kclrb (= 1.0.0)
+  circuitbox
   elasticsearch (~> 1.1.2)
   faraday_middleware
   faraday_middleware-aws-signers-v4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   elasticsearch:
-    image: elasticsearch:1.5.2
+    image: elasticsearch:1.5
     # ports:
     #   - "9200:9200"
     #   - "9300:9300"

--- a/lib/api/api.rb
+++ b/lib/api/api.rb
@@ -40,6 +40,11 @@ module Stats
         [404, json({ message: 'Bad Request' })]
       end
 
+      # handle the 503 circuitbreaker errors
+      error Elasticsearch::Transport::Transport::Errors::ServiceUnavailable do
+        [503, json({ message: 'Service unavailable due to overload' })]
+      end
+
       private
 
       def format_results(results)

--- a/lib/es/client.rb
+++ b/lib/es/client.rb
@@ -29,9 +29,31 @@ module Stats
           expires_in: cache_expires_in.minutes
         )
         Elasticsearch::Client.new(config) do |f|
-          f.use Stats::Es::RequestCache, cache
+          if service == :api
+            require 'circuitbox/faraday_middleware'
+            # add ES query request caching - ensure this is before the circuit breakers
+            # so we use the cached responses even when ES may be overloaded
+            f.use Stats::Es::RequestCache, cache
 
-          # use the middleware signers when talking to the elastic
+            # add circuitbox middleware to handle ES transport failures
+            # while load shedding to avoid a ES cluster issues
+            f.use Circuitbox::FaradayMiddleware,
+              # https://github.com/yammer/circuitbox/tree/v1.1.1#faraday
+              open_circuit: lambda { |response|
+                # nil -> connection could not be established, or failed very hard
+                # 5xx -> non recoverable server error opposed to 4xx which are client errors
+                # 429 -> too many requests / ES is overwhelemed with queries
+                #        Elasticsearch::Transport::Transport::ServerError [429]
+                #        {"error":"SearchPhaseExecutionException[Failed to execute phase [query], all shards failed; shardFailures ...." }
+                response.status.nil? || (response.status >= 500 && response.status <= 599) || response.status == 429
+              },
+              # https://github.com/yammer/circuitbox/tree/v1.1.1#faraday
+              circuit_breaker_options: {
+                sleep_window: 60, # open the circuit / sleep for 1 minute before retrying https://github.com/yammer/circuitbox/blob/89aab2085dbf6f98ff7f8fc40a314103602f98da/lib/circuitbox/circuit_breaker.rb#L18
+              }
+          end
+
+          # use the AWS middleware signers when talking to the AWS ES cluster
           unless dev_env?
             f.request :aws_signers_v4,
               credentials: Aws::Credentials.new(es_config["aws_key"], es_config["aws_secret"]),
@@ -41,7 +63,7 @@ module Stats
 
           # add es transport client request logging only via $stderr
           # https://github.com/awslabs/amazon-kinesis-client-ruby/blob/96f149a4a2a5ac215f0cdb26252b0f68afb96d00/samples/sample_kcl.rb#L24-L27
-          f.response(:logger, Logger.new($stderr, level: Logger::INFO)) if ENV.fetch('ES_TRANSPORT_LOGGING', false)
+          f.response(:logger, Logger.new($stderr, level: Logger::DEBUG)) if ENV.fetch('ES_TRANSPORT_LOGGING', false)
           # specify the underlying transport faraday adatper
           # https://github.com/elastic/elasticsearch-ruby/tree/1.x/elasticsearch-transport#transport-implementations
           f.adapter :typhoeus


### PR DESCRIPTION
This PR adds a 'circuit breaker' pattern to the APIs ElasticSearch client. Specifically it uses https://github.com/yammer/circuitbox#faraday to provide circuit breaker system to ES faraday adapter

When the ES server responds with server errors 500+ or 429 responses (too busy) this will 'open' the circuit es client adapter. Once 'opened' the adapter will stop querying the cluster for 60s before trying again.

On an 'open' circuit the stats system will return a HTTP 503 message to indicate the system is overloaded.

This allows load shedding when the cluster is at capacity instead of adding to the backlog of queries to resolve.