### PR TITLE
try to configure pods to stay alive

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -3,7 +3,7 @@
 env = ENV.fetch('RACK_ENV', 'development')
 port = ENV.fetch('PORT', 80)
 environment env
-threads_count = ENV.fetch('PUMA_MAX_THREADS', 4).to_i
+threads_count = ENV.fetch('PUMA_MAX_THREADS', 12).to_i
 # === Non-Cluster mode (no worker / forking) ===
 threads 1, threads_count
 bind "tcp://0.0.0.0:#{port}"

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -52,6 +52,7 @@ spec:
             # allow a longer response time than 1s
             timeoutSeconds: 30
             periodSeconds: 30
+            failureThreshold: 6
           readinessProbe:
             httpGet:
               path: /

--- a/lib/es/client.rb
+++ b/lib/es/client.rb
@@ -81,7 +81,8 @@ module Stats
       def defaults
         # reload host connections on failure
         # https://github.com/elastic/elasticsearch-ruby/tree/1.x/elasticsearch-transport#reloading-hosts
-        @defaults = { log: es_logging?, index: 'zoo-events', reload_on_failure: true }
+        # and timeout long running requests
+        @defaults = { log: es_logging?, index: 'zoo-events', reload_on_failure: true, request_timeout: ENV.fetch('ES_REQUEST_TIMEOUT', '120').to_i }
       end
 
       def es_config

--- a/lib/es/client.rb
+++ b/lib/es/client.rb
@@ -50,6 +50,7 @@ module Stats
               # https://github.com/yammer/circuitbox/tree/v1.1.1#faraday
               circuit_breaker_options: {
                 sleep_window: 60, # open the circuit / sleep for 1 minute before retrying https://github.com/yammer/circuitbox/blob/89aab2085dbf6f98ff7f8fc40a314103602f98da/lib/circuitbox/circuit_breaker.rb#L18
+                volume_threshold: 1, # number of requests before calculating the error rates
               }
           end
 


### PR DESCRIPTION
this pr adds 
- a 2 min es client request timeout
- bumping to 12 puma threads so we may have 1 alive to serve the health checks
- count failures for circuit breaker after 1 request
- increase liveness probe failure threshold to 6 to allow requests to timeout and free up for health checks endpoint